### PR TITLE
Allow API Calls Without User Agents

### DIFF
--- a/restrictedsessions/middleware.py
+++ b/restrictedsessions/middleware.py
@@ -95,4 +95,4 @@ class RestrictedSessionsMiddleware(MiddlewareMixin):
         if SESSION_UA_KEY not in request.session:
             return True
         # Compare the new user agent value with what is known about the session
-        return request.session[SESSION_UA_KEY] == force_text(request.META.get(['HTTP_USER_AGENT']), errors='replace')
+        return request.session[SESSION_UA_KEY] == force_text(request.META.get('HTTP_USER_AGENT'), errors='replace')

--- a/restrictedsessions/middleware.py
+++ b/restrictedsessions/middleware.py
@@ -95,4 +95,4 @@ class RestrictedSessionsMiddleware(MiddlewareMixin):
         if SESSION_UA_KEY not in request.session:
             return True
         # Compare the new user agent value with what is known about the session
-        return request.session[SESSION_UA_KEY] == force_text(request.META['HTTP_USER_AGENT'], errors='replace')
+        return request.session[SESSION_UA_KEY] == force_text(request.META.get(['HTTP_USER_AGENT']), errors='replace')

--- a/restrictedsessions/middleware.py
+++ b/restrictedsessions/middleware.py
@@ -47,7 +47,7 @@ class RestrictedSessionsMiddleware(MiddlewareMixin):
             logger.warning("Destroyed session due to invalid change of remote host or user agent")
             redirect_view = getattr(settings, 'RESTRICTEDSESSIONS_REDIRECT_VIEW', None)
             # Unauthorize if the request contains neither a remote IP or User Agent
-            if not self.validate_ip(request, remote_addr) and not self.validate_ua(request):
+            if not remote_addr and not request.META.get('HTTP_USER_AGENT'):
                 status = getattr(settings, 'RESTRICTEDSESSIONS_FAILURE_STATUS', 401)
                 return HttpResponse(status=status)
             if redirect_view:

--- a/restrictedsessions/middleware.py
+++ b/restrictedsessions/middleware.py
@@ -47,7 +47,7 @@ class RestrictedSessionsMiddleware(MiddlewareMixin):
             logger.warning("Destroyed session due to invalid change of remote host or user agent")
             redirect_view = getattr(settings, 'RESTRICTEDSESSIONS_REDIRECT_VIEW', None)
             # Unauthorize if the request contains neither a remote IP or User Agent
-            if 'api' in request.build_absolute_uri():
+            if 'api' in request.get_full_path():
                 status = getattr(settings, 'RESTRICTEDSESSIONS_FAILURE_STATUS', 401)
                 return HttpResponse(status=status)
             if redirect_view:

--- a/restrictedsessions/middleware.py
+++ b/restrictedsessions/middleware.py
@@ -33,6 +33,11 @@ class RestrictedSessionsMiddleware(MiddlewareMixin):
             if not user or not hasattr(user, 'is_authenticated') or not user.is_authenticated():
                 return
 
+        # Unauthorize if the request contains no headers
+        if not request.headers:
+            status = getattr(settings, 'RESTRICTEDSESSIONS_FAILURE_STATUS', 401)
+            return HttpResponse(status=status)
+            
         # Extract remote IP address for validation purposes
         remote_addr_key = getattr(settings, 'RESTRICTEDSESSIONS_REMOTE_ADDR_KEY', 'REMOTE_ADDR')
         remote_addr = request.META.get(remote_addr_key)

--- a/restrictedsessions/middleware.py
+++ b/restrictedsessions/middleware.py
@@ -47,7 +47,7 @@ class RestrictedSessionsMiddleware(MiddlewareMixin):
             logger.warning("Destroyed session due to invalid change of remote host or user agent")
             redirect_view = getattr(settings, 'RESTRICTEDSESSIONS_REDIRECT_VIEW', None)
             # Unauthorize if the request contains neither a remote IP or User Agent
-            if not remote_addr and not request.META.get('HTTP_USER_AGENT'):
+            if 'api' in request.build_absolute_uri():
                 status = getattr(settings, 'RESTRICTEDSESSIONS_FAILURE_STATUS', 401)
                 return HttpResponse(status=status)
             if redirect_view:


### PR DESCRIPTION
Current implementation does not handle sessions missing the user agent header. It is not uncommon for requests made via API's to lack an user agent in their headers. According to RFC 7231, the user agent header is not mandatory. 

This line will produce an error resulting in a 500 response from the server if there does not exist an user agent for the session and user agent restriction is enabled. In order to avoid the error, use the .get method which will substitute None if a key cannot be found. This fix prevents the error while continuing to allow user agent restriction for sessions based on browser and appropriately handle an API-based session if it lacks the header.